### PR TITLE
Fix: open file with trunc mode by default

### DIFF
--- a/pkg/client/directory.go
+++ b/pkg/client/directory.go
@@ -79,7 +79,7 @@ func (d *directory) WriteFile(_ context.Context, fileName string, opt WriteOptio
 		}
 	}
 
-	flags := os.O_WRONLY | os.O_CREATE
+	flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
 	if opt.WithoutCreate {
 		flags ^= os.O_CREATE
 	}


### PR DESCRIPTION
By default it should open with trunc mode so that when we write existing file we can override the content. Otherwise it will be invalid json data. 

https://github.com/gptscript-ai/otto/issues/128